### PR TITLE
Fix import() file names not being replaced

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -8,7 +8,7 @@ export { Program, CompilerOptions } from "typescript";
 
 const vm = require("vm");
 
-const REGEX_FILE_NAME = /".*"\./;
+const REGEX_FILE_NAME = /(import\()?".*"\)?\./;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;
 const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -755,7 +755,7 @@ export class JsonSchemaGenerator {
                     reffedType!
             ).replace(REGEX_FILE_NAME, "");
         } else if (asRef) {
-            fullTypeName = this.getTypeName(typ, tc);
+            fullTypeName = this.getTypeName(typ, tc).replace(REGEX_FILE_NAME, "");
         }
 
         if (asRef) {


### PR DESCRIPTION
Please:
- [ ] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [ ] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation in the `Readme.md`

In electron-webpack's recent versions, it has not be successfully replacing the file names because they are wrapped in an import statement like the following (taken from v2.7.0):
`        "import(\"/Volumes/data/Documents/electron-webpack/packages/electron-webpack/src/core\").ElectronWebpackConfigurationMain": {`

This fixes the exported schema so that it only outputs the correct out:
`        "ElectronWebpackConfigurationMain": {`